### PR TITLE
Deprecated IsArray and IsString APIs

### DIFF
--- a/src/input.ts
+++ b/src/input.ts
@@ -37,7 +37,7 @@ export function validateArgs(args: ParsedArgs): void {
     process.exit(1);
   }
 
-  if (args._.length < 3 || args.o === true || isArray(args.o) || isString(args.p) || isArray(args.p)) {
+  if (args._.length < 3 || args.o === true || Array.isArray(args.o) || typeof args.p === "string" || Array.isArray(args.p)) {
     // Input error
     printHelp();
   }

--- a/src/input.ts
+++ b/src/input.ts
@@ -1,5 +1,4 @@
 import { ParsedArgs } from 'minimist';
-import { isArray, isString } from 'util';
 import { toJson } from 'xml2json';
 import { CoberturaJson } from './types/cobertura';
 import * as fs from 'fs';


### PR DESCRIPTION
Fixes the following deprecated API calls:

(node:6428) [DEP0044] DeprecationWarning: The `util.isArray` API is deprecated. Please use `Array.isArray()` instead.
(node:6428) [DEP0056] DeprecationWarning: The `util.isString` API is deprecated.  Please use `typeof arg === "string"` instead.

* Array.IsArray(x) replaces IsArray(x)
* typeof x === "string" replaces isString(x)
* 
